### PR TITLE
Change DB connection handling

### DIFF
--- a/bin/auto_accession.sh
+++ b/bin/auto_accession.sh
@@ -17,8 +17,8 @@ accession_type=$1
 [ ! -z ${SCXA_METADATA_REPO+x} ] || ( echo "SCXA_METADATA_REPO ie. Gitlab repo" && exit 1 )
 
 
-dbConnection=$(get_db_connection atlasprd3 pro)
-scdbConnection=$(get_pg_db_connection -u 'atlasprd3' -d 'pro' -t 'scxa')
+dbConnection=$(get_db_connection)
+scdbConnection=$(get_pg_db_connection)
 
 ## check for loaded studies im DB in bulk and single cell
 max_db_id=$(psql -d "$dbConnection" -a -v TYPE="E-${accession_type}" -f $scriptDir/auto_accession.sql | grep "E-${accession_type}-" | tail -n1 | sed 's/[^0-9]*//g')
@@ -35,11 +35,11 @@ fi
 pushd $meta_clone > /dev/null
 git checkout master && git pull > /dev/null
 popd > /dev/null
-	
+
 ## Ongoing single cell
 max_sc_id=$(find $meta_clone/${accession_type} -type f -name "E-$accession_type-*" -exec basename {} ';' | sed 's/[^0-9]*//g' | sort -nr | head -n1)
 
-## ongoing curation 
+## ongoing curation
 if [ $accession_type == 'CURD' ]; then
 	max_curation=$(find $AE2_BASE_DIR/${accession_type} -type d -exec basename {} ';' |  sed 's/[^0-9]*//g' | sort -nr | head -n1)
 elif [ $accession_type == 'ENAD' ]; then

--- a/bin/geo_import_cron.sh
+++ b/bin/geo_import_cron.sh
@@ -4,20 +4,13 @@
 scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 projectRoot=${scriptDir}/..
 source $projectRoot/bin/geo_import_routines.sh
-# This is resovled via the atlas-bash-utils conda package
-source generic_routines.sh
 
 today="`eval date +%Y-%m-%d`"
 
-USAGE="Usage: `basename $0` [-u pgAtlasUser ] [-d dbIdentifier ] [-t bulkORsinglecell ] [-s supportingFilesPath ] [-o output ]"
+USAGE="Usage: `basename $0` [-t bulkORsinglecell ] [-s supportingFilesPath ] [-o output ]"
     while getopts ":u:d:t:s:o:" params; do
         case $params in
-            u)
-                pgAtlasUser=$OPTARG;
-                ;;
-            d)
-                dbIdentifier=$OPTARG;
-                ;;
+
             t)
                 bulkORsinglecell=$OPTARG;
                 ;;
@@ -51,7 +44,7 @@ if [ ! -d "$supportingFilesPath" ]; then
 fi
 
 # Set up DB connection details
-dbConnection=$(get_db_connection $pgAtlasUser $dbIdentifier)
+dbConnection=$(get_pg_db_connection)
 if [ $? -ne 0 ]; then
     echo "ERROR: dbConnection connection not established" >&2
     exit 1


### PR DESCRIPTION
This update changes the way the database connection is passed in. Previously user and DB name were used as command line arguments and the host/password was taken from the file system (via the bash_util generic routine).
To remove this dependency on the file system path and the mixed handling of credentials, I've updated the `get_pg_db_connection` routine to expect the full connection string as ENV variable `$dbConnection`. 

Note, the auto_accession.sh script will likely not work properly like this because there is no distinction between bulk and sc database. However, the script's logic isn't up-to-date and it is currently not in use. So more changes are needed that are out of scope here. 