### PR TITLE
Remove last step that copies files to GEOD folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ For microarrays, the -x should not be used as we need to download raw (.cel/txt)
 A python script `rnaseq_ena_gse_pooling.py` is used to retrieve ENA study ids and convert to GEO based GSE ids. This script depends on RNA-seqer API, which is used to retrieve ENA study ids and organism names from ENA (http://www.ebi.ac.uk/fg/rnaseq/api/json/getBulkRNASeqStudiesInSRA). GEO studies that have been previously downloaded in ArrayExpress (AE2) are filtered, so there are no redundant downloads. NCBI eutilis (http://eutils.ncbi.nlm.nih.gov/entrez/eutils) is used for converting filtered ENA study id to GSE id. The output list of converted GSE ids are stored as `geo_rnaseq.tsv` under `geo_import_supporting_files`. ENA ids that do not have meta-data in GEO are recorded in `NotInGEO_list.txt` that has ENA study id and associated organism name which may be useful for curators to prioritise for ENA import.
 
 The `geo_import_cron.sh` script encapsulates this process and goes on to filter the GSExx ids (`geo_rnaseq.tsv`) list further to remove GSE ids that already exist in the `atlas_eligibility` table in the atlasprd3 database. The process produces a latest GEO accessions list `latest_geo_accessions.txt` ready to run batch GEO import.
+
+After the batch import is run, the `geo_import_magetab_eligibility.sh` script crawls the Downloads directory and runs 
+1) MAGE-TAB split into IDF/SDRF, 
+2) Atlas eligibility check,
+3) recording of the dataset in the database. 
+
+The optional parameter `-c` can be used to specify a "curation directory" where to copy the generated MAGE-TAB files. 

--- a/bin/geo_import_magetab_eligibility.sh
+++ b/bin/geo_import_magetab_eligibility.sh
@@ -60,10 +60,13 @@ if [ ! -d "$pathToDownloads" ]; then
     exit 1;
 fi
 
-#if [ ! -d "$pathToCuration" ]; then
-#    echo "path to curation $pathToCuration doesn't exist"
-#    exit 1;
-#fi
+# Optional variable to perform copy
+if [ ! -z "$pathToCuration" ]; then
+    if [ ! -d "$pathToCuration" ]; then
+        echo "path to curation $pathToCuration doesn't exist"
+        exit 1;
+    fi
+fi
 
 # Set up DB connection details
 dbConnection=$(get_pg_db_connection)
@@ -114,6 +117,9 @@ find ${pathToDownloads} -mindepth 1 -maxdepth 1 | xargs -n1 basename \
 done
 
 
-### create atlas accession folders (E-GEOD-xxx) under associated bulk or singlecell RNA-seq and sync all mage-tab files for curation
-#echo "Creating folders and moving files for new studies"
-#move_files $pathToDownloads $pathToCuration
+# Optional if path is given: create atlas accession folders (E-GEOD-xxx) under associated bulk or singlecell RNA-seq
+# and sync all mage-tab files for curation
+if [ ! -z "$pathToCuration" ]; then
+    echo "Creating folders and moving files for new studies"
+    move_files $pathToDownloads $pathToCuration
+fi

--- a/bin/geo_import_magetab_eligibility.sh
+++ b/bin/geo_import_magetab_eligibility.sh
@@ -60,10 +60,10 @@ if [ ! -d "$pathToDownloads" ]; then
     exit 1;
 fi
 
-if [ ! -d "$pathToCuration" ]; then
-    echo "path to curation $pathToCuration doesn't exist"
-    exit 1;
-fi
+#if [ ! -d "$pathToCuration" ]; then
+#    echo "path to curation $pathToCuration doesn't exist"
+#    exit 1;
+#fi
 
 # Set up DB connection details
 dbConnection=$(get_pg_db_connection)
@@ -114,6 +114,6 @@ find ${pathToDownloads} -mindepth 1 -maxdepth 1 | xargs -n1 basename \
 done
 
 
-## create atlas accession folders (E-GEOD-xxx) under associated bulk or singlecell RNA-seq and sync all mage-tab files for curation
-echo "Creating folders and moving files for new studies"
-move_files $pathToDownloads $pathToCuration
+### create atlas accession folders (E-GEOD-xxx) under associated bulk or singlecell RNA-seq and sync all mage-tab files for curation
+#echo "Creating folders and moving files for new studies"
+#move_files $pathToDownloads $pathToCuration

--- a/bin/geo_import_magetab_eligibility.sh
+++ b/bin/geo_import_magetab_eligibility.sh
@@ -95,16 +95,20 @@ find ${pathToDownloads} -mindepth 1 -maxdepth 1 | xargs -n1 basename \
                 echo "Atlas eligility check - $expAcc"
                 check_atlas_eligibility.pl -m ${expAcc}.merged.idf.txt > ${expAcc}_atlas_eligibility.out
 
+                echo "Creating Atlas MAGE-TAB files - $expAcc"
+                create_atlas_accession_files $expAcc $bulkORsinglecell
+
                 echo "Loading in the database - $expAcc"
                 exp_loading_check $expAcc $geoEnaMappingFile $dbConnection $bulkORsinglecell $pathToDownloads
+
 	        else
                 echo "${expAcc}_atlas_eligibility already done"
                 exp_loading_check $expAcc $geoEnaMappingFile $dbConnection $bulkORsinglecell $pathToDownloads
                 echo "Loaded in the database - $expAcc"
             fi
-      else
+    else
 	      echo "MAGE-TAB files for $expAcc missing"
-      fi
+    fi
 
     popd
 done

--- a/bin/geo_import_routines.sh
+++ b/bin/geo_import_routines.sh
@@ -185,8 +185,8 @@ create_atlas_accession_files(){
         sed 's/ArrayExpressAccession/ExpressionAtlasAccession/g' > "${atlas_id}-idf.txt"
         # Add SDRF File ref to IDF
         echo -e "SDRF File\t${atlas_id}-sdrf.txt" >> "${atlas_id}-idf.txt"
-        # Create the SDRF
-        cp "${expAcc}-sdrf.txt" "${atlas_id}-sdrf.txt"
+        # Update BioSample accession comment in the SDRF
+        sed -e 's/Comment \[BIOSAMPLE\]/Comment [BioSD_SAMPLE]/' "${expAcc}-sdrf.txt" > "${atlas_id}-sdrf.txt"
 
         # Extra modifications for single cell experiments
         if [[ "$bulkORsinglecell" =~ "singlecell" ]]; then

--- a/bin/geo_import_routines.sh
+++ b/bin/geo_import_routines.sh
@@ -115,61 +115,61 @@ atlas_loaded_experiments(){
   echo -e "$expLoaded\n$inAtlas" | sed 's/ //g'
 }
 
-# function to create experiment accession directory and move all processed files to GEOD
-move_files(){
-  pathToDownloads=$1
-  pathToCuration=$2
-
-  pushd "$pathToDownloads"
-  for f in *; do
-    expAcc=$(basename "$f" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
-
-    echo "making directory $expAcc"
-    exp_dir="$pathToCuration/$expAcc"
-
-    if [ ! -d "$exp_dir" ]; then
-      mkdir -p "$exp_dir"
-    fi
-
-    ## while copying preserve time stamps and exlude merged magetab
-    rsync -ar --exclude="*.idf.txt" $pathToDownloads/$f/*txt* $exp_dir/
-
-    # rename files with ArrayExpress accession prefix
-    rename_magetab_files $exp_dir
-  done
-  popd
-}
-
-rename_magetab_files(){
-  pathToMagetabDir=$1
-
-  pushd "$pathToMagetabDir"
-  ## rename all files in the folder
-  for filename in *.txt*; do
-    mv "$filename" "$(echo "$filename" | sed 's/GSE/E-GEOD-/g')";
-  done
-  popd
-}
-
-sync_experiments_folder(){
-  expID=$1
-  pathToDownloads=$2
-  pathToCuration=$3
-
-  ## create ArrayExpress accession
-  expAcc=$(basename "$expID" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
-
-  exp_dir_path="$pathToCuration/$expAcc"
-
-  if [ ! -d "exp_dir_path" ]; then
-    mkdir -p "$exp_dir_path"
-    # sync files
-    rsync -ar $pathToDownloads/$expID/*txt* $exp_dir_path/
-
-    # rename files with ArrayExpress accession prefix
-    rename_magetab_files $exp_dir_path
-  fi
-}
+## function to create experiment accession directory and move all processed files to GEOD
+#move_files(){
+#  pathToDownloads=$1
+#  pathToCuration=$2
+#
+#  pushd "$pathToDownloads"
+#  for f in *; do
+#    expAcc=$(basename "$f" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
+#
+#    echo "making directory $expAcc"
+#    exp_dir="$pathToCuration/$expAcc"
+#
+#    if [ ! -d "$exp_dir" ]; then
+#      mkdir -p "$exp_dir"
+#    fi
+#
+#    ## while copying preserve time stamps and exlude merged magetab
+#    rsync -ar --exclude="*.idf.txt" $pathToDownloads/$f/*txt* $exp_dir/
+#
+#    # rename files with ArrayExpress accession prefix
+#    rename_magetab_files $exp_dir
+#  done
+#  popd
+#}
+#
+#rename_magetab_files(){
+#  pathToMagetabDir=$1
+#
+#  pushd "$pathToMagetabDir"
+#  ## rename all files in the folder
+#  for filename in *.txt*; do
+#    mv "$filename" "$(echo "$filename" | sed 's/GSE/E-GEOD-/g')";
+#  done
+#  popd
+#}
+#
+#sync_experiments_folder(){
+#  expID=$1
+#  pathToDownloads=$2
+#  pathToCuration=$3
+#
+#  ## create ArrayExpress accession
+#  expAcc=$(basename "$expID" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
+#
+#  exp_dir_path="$pathToCuration/$expAcc"
+#
+#  if [ ! -d "exp_dir_path" ]; then
+#    mkdir -p "$exp_dir_path"
+#    # sync files
+#    rsync -ar $pathToDownloads/$expID/*txt* $exp_dir_path/
+#
+#    # rename files with ArrayExpress accession prefix
+#    rename_magetab_files $exp_dir_path
+#  fi
+#}
 
 
 # Rename the final MAGE-TAB files to their accession and do some helpful modification for curators

--- a/bin/geo_import_routines.sh
+++ b/bin/geo_import_routines.sh
@@ -115,61 +115,61 @@ atlas_loaded_experiments(){
   echo -e "$expLoaded\n$inAtlas" | sed 's/ //g'
 }
 
-## function to create experiment accession directory and move all processed files to GEOD
-#move_files(){
-#  pathToDownloads=$1
-#  pathToCuration=$2
-#
-#  pushd "$pathToDownloads"
-#  for f in *; do
-#    expAcc=$(basename "$f" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
-#
-#    echo "making directory $expAcc"
-#    exp_dir="$pathToCuration/$expAcc"
-#
-#    if [ ! -d "$exp_dir" ]; then
-#      mkdir -p "$exp_dir"
-#    fi
-#
-#    ## while copying preserve time stamps and exlude merged magetab
-#    rsync -ar --exclude="*.idf.txt" $pathToDownloads/$f/*txt* $exp_dir/
-#
-#    # rename files with ArrayExpress accession prefix
-#    rename_magetab_files $exp_dir
-#  done
-#  popd
-#}
-#
-#rename_magetab_files(){
-#  pathToMagetabDir=$1
-#
-#  pushd "$pathToMagetabDir"
-#  ## rename all files in the folder
-#  for filename in *.txt*; do
-#    mv "$filename" "$(echo "$filename" | sed 's/GSE/E-GEOD-/g')";
-#  done
-#  popd
-#}
-#
-#sync_experiments_folder(){
-#  expID=$1
-#  pathToDownloads=$2
-#  pathToCuration=$3
-#
-#  ## create ArrayExpress accession
-#  expAcc=$(basename "$expID" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
-#
-#  exp_dir_path="$pathToCuration/$expAcc"
-#
-#  if [ ! -d "exp_dir_path" ]; then
-#    mkdir -p "$exp_dir_path"
-#    # sync files
-#    rsync -ar $pathToDownloads/$expID/*txt* $exp_dir_path/
-#
-#    # rename files with ArrayExpress accession prefix
-#    rename_magetab_files $exp_dir_path
-#  fi
-#}
+# function to create experiment accession directory and move all processed files to GEOD
+move_files(){
+  pathToDownloads=$1
+  pathToCuration=$2
+
+  pushd "$pathToDownloads"
+  for f in *; do
+    expAcc=$(basename "$f" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
+
+    echo "making directory $expAcc"
+    exp_dir="$pathToCuration/$expAcc"
+
+    if [ ! -d "$exp_dir" ]; then
+      mkdir -p "$exp_dir"
+    fi
+
+    ## while copying preserve time stamps and exlude merged magetab
+    rsync -ar --exclude="*.idf.txt" $pathToDownloads/$f/*txt* $exp_dir/
+
+    # rename files with ArrayExpress accession prefix
+    rename_magetab_files $exp_dir
+  done
+  popd
+}
+
+rename_magetab_files(){
+  pathToMagetabDir=$1
+
+  pushd "$pathToMagetabDir"
+  ## rename all files in the folder
+  for filename in *.txt*; do
+    mv "$filename" "$(echo "$filename" | sed 's/GSE/E-GEOD-/g')";
+  done
+  popd
+}
+
+sync_experiments_folder(){
+  expID=$1
+  pathToDownloads=$2
+  pathToCuration=$3
+
+  ## create ArrayExpress accession
+  expAcc=$(basename "$expID" | sed 's/_output//g' | sed 's/GSE/E-GEOD-/g')
+
+  exp_dir_path="$pathToCuration/$expAcc"
+
+  if [ ! -d "exp_dir_path" ]; then
+    mkdir -p "$exp_dir_path"
+    # sync files
+    rsync -ar $pathToDownloads/$expID/*txt* $exp_dir_path/
+
+    # rename files with ArrayExpress accession prefix
+    rename_magetab_files $exp_dir_path
+  fi
+}
 
 
 # Rename the final MAGE-TAB files to their accession and do some helpful modification for curators

--- a/bin/geo_import_routines.sh
+++ b/bin/geo_import_routines.sh
@@ -171,6 +171,37 @@ sync_experiments_folder(){
   fi
 }
 
+
+# Rename the final MAGE-TAB files to their accession and do some helpful modification for curators
+create_atlas_accession_files(){
+    expAcc=$1
+    bulkORsinglecell=$2
+
+    # In the folder with the raw imported/split MAGE-TAB files
+    if [[ -e "${expAcc}-idf.txt" ]]; then
+        atlas_id=$(echo -e "$expAcc" | sed 's/GSE/E-GEOD-/g')
+        # Remove ArrayExpressSubmissionDate comment and rename accession comment in IDF
+        grep -v "ArrayExpressSubmissionDate" "${expAcc}-idf.txt" | \
+        sed 's/ArrayExpressAccession/ExpressionAtlasAccession/g' > "${atlas_id}-idf.txt"
+        # Add SDRF File ref to IDF
+        echo -e "SDRF File\t${atlas_id}-sdrf.txt" >> "${atlas_id}-idf.txt"
+        # Create the SDRF
+        cp "${expAcc}-sdrf.txt" "${atlas_id}-sdrf.txt"
+
+        # Extra modifications for single cell experiments
+        if [[ "$bulkORsinglecell" =~ "singlecell" ]]; then
+            # Change experiment type
+            sed -i "" -e 's/\tRNA-seq of coding RNA/\tRNA-seq of coding RNA from single cells/' "${atlas_id}-idf.txt"
+            # Add single cell IDF comments to be filled by curators
+            echo -e "Comment[EACurator]\nComment[EAExpectedClusters]\nComment[EAExperimentType]\nComment[EAAdditionalAttributes]" >> "${atlas_id}-idf.txt"
+        fi
+
+    else
+        echo "Could not find split MAGE-TAB files for ${expAcc}"
+    fi
+}
+
+
 exp_loading_check(){
   expAcc=$1
   geoEnaMappingFile=$2


### PR DESCRIPTION
The last step of the pipeline is to move and rename the MAGE-TAB files to the `GEOD` curation folder where the final curated MAGE-TAB files live. This copying is not really needed and had a risk potential to overwrite curated MAGE-TAB files. 

This change removes the last step. Instead we are doing the renaming in the downloads folder. 
Also a few other helpful modifications are introduced at this step:
- Remove "ArrayExpressSubmissionDate" comment in IDF
- Change "ArrayExpressAccession" to "ExpressionAtlasAccession" 
- Add "SDRF File" reference in IDF
- Rename BioSample accession comment to "BioSD_SAMPLE"
- For single cell, add single cell comments to IDF and change default experiment type to "RNA-seq of coding RNA from single cells"

For backwards compatibility, the copy operation is kept as an optional step. Whenever the "pathToCuration/-c" argument is specified the process is run. If not specified, it is left out.  