### PR TITLE
Replace dependency on RNA-seqer API to get accession lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For microarrays, the -x should not be used as we need to download raw (.cel/txt)
 
 ## Subprocesses
 
-A python script `rnaseq_ena_gse_pooling.py` is used to retrieve ENA study ids and convert to GEO based GSE ids. This script depends on RNA-seqer API, which is used to retrieve ENA study ids and organism names from ENA (http://www.ebi.ac.uk/fg/rnaseq/api/json/getBulkRNASeqStudiesInSRA). GEO studies that have been previously downloaded in ArrayExpress (AE2) are filtered, so there are no redundant downloads. NCBI eutilis (http://eutils.ncbi.nlm.nih.gov/entrez/eutils) is used for converting filtered ENA study id to GSE id. The output list of converted GSE ids are stored as `geo_rnaseq.tsv` under `geo_import_supporting_files`. ENA ids that do not have meta-data in GEO are recorded in `NotInGEO_list.txt` that has ENA study id and associated organism name which may be useful for curators to prioritise for ENA import.
+A python script `geo_studies_list.py` is used to retrieve GEO study to SRA study accession mappings. The output list of retrieved GSE ids is stored as `geo_{bulkOrSinglecell}_rnaseq.tsv` under `geo_import_supporting_files`. 
 
-The `geo_import_cron.sh` script encapsulates this process and goes on to filter the GSExx ids (`geo_rnaseq.tsv`) list further to remove GSE ids that already exist in the `atlas_eligibility` table in the atlasprd3 database. The process produces a latest GEO accessions list `latest_geo_accessions.txt` ready to run batch GEO import.
+The `geo_import_cron.sh` script encapsulates this process and goes on to filter the GSExx ids (`geo_{bulkOrSinglecell}_rnaseq.tsv`) list further to remove GSE ids that already exist in the `atlas_eligibility` table in the Atlasprod database. The process produces a latest GEO accessions list `latest_geo_accessions.txt` ready to run batch GEO import.
 
 After the batch import is run, the `geo_import_magetab_eligibility.sh` script crawls the Downloads directory and runs 
 1) MAGE-TAB split into IDF/SDRF, 

--- a/bin/geo_studies_list.py
+++ b/bin/geo_studies_list.py
@@ -1,0 +1,105 @@
+"""Script to generate a list of GEO brokered ENA transcriptomics studies that have raw data"""
+
+import argparse
+import json
+import re
+from os import path
+from sys import exit
+
+import pandas as pd
+import requests
+import xmltodict
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-t', '--type', help='Please provide type as "bulk" or "singlecell"', required=True)
+    parser.add_argument('-o', '--output', help='Please provide absolute path to output directory"', required=True)
+    return parser.parse_args()
+
+
+# Pattern to find single cell studies
+sc_regex = re.compile("single[ _-]cell|cell-to-cell|scRNA|10x|single[ _-]nucleus|snRNA-seq", re.IGNORECASE)
+
+
+def is_singlecell(title):
+    """Determine single cell experiments based on title"""
+    if title:
+        if sc_regex.search(title):
+            return True
+    return False
+
+
+def get_geo_study_list(bulk_or_singlecell):
+    """Fetch list of GEO-brokered transcriptomics studies via ENA API
+    and parse study XML to read title and organism.
+    Returns a Pandas data frame for the given type (bulk or single cell)."""
+
+    limit = "100000"
+    library_source = "TRANSCRIPTOMIC"
+
+    ena_query = f"https://www.ebi.ac.uk/ena/browser/api/xml/search?result=read_study&query=library_source%3D%22{library_source}%22%20AND%20center_name%3D%22GEO%22&limit={limit}&gzip=false&dataPortal=ena&includeMetagenomes=false"
+
+    u = requests.get(ena_query)
+    raw_xml = u.text
+    xml_dict = xmltodict.parse(raw_xml)
+
+    bulk_studies = []
+    singlecell_studies = []
+
+    for project in xml_dict.get("PROJECT_SET", {}).get("PROJECT"):
+        study = {}
+
+        ids = project.get("IDENTIFIERS", {})
+        study["project"] = ids.get("PRIMARY_ID")
+        study["study"] = ids.get("SECONDARY_ID")
+        study["geo"] = ids.get("EXTERNAL_ID", {}).get("#text", "")
+
+        # For some studies the ENA study accession is missing, let's look it up
+        if study["geo"] and not study["study"]:
+            study["study"] = lookup_sra_study(study["geo"])
+
+        study["title"] = project.get("TITLE", "")
+        study["taxonomy"] = project.get("SUBMISSION_PROJECT", {}).get("ORGANISM", {}).get("SCIENTIFIC_NAME", "")
+
+        # Sort by single cell
+        if is_singlecell(study["title"]):
+            singlecell_studies.append(study)
+        else:
+            bulk_studies.append(study)
+
+    if bulk_or_singlecell == "singlecell":
+        return pd.DataFrame.from_records(singlecell_studies)
+
+    elif bulk_or_singlecell == "bulk":
+        return pd.DataFrame.from_records(bulk_studies)
+
+
+def lookup_sra_study(geo_accession):
+    """Use EBI search API to retrieve the SRA study accession for a given GEO study accession
+    if it is not found in the study XML"""
+
+    ebi_query = f"https://www.ebi.ac.uk/ebisearch/ws/rest/nucleotideSequences?query={geo_accession}&format=json"
+
+    u = requests.get(ebi_query)
+    result = json.loads(u.text)
+    for entry in result.get("entries", []):
+        if entry.get("source", "") == "sra-study":
+            return entry.get("id", "")
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    if args.type not in ("bulk", "singlecell"):
+        print("Type is not recognised. Must be \"bulk\" or \"singlecell\".")
+        exit(1)
+
+    if not path.exists(args.output):
+        print("Output path does not exist.")
+        exit(1)
+
+    output_file = path.join(args.output, "geo_{}_rnaseq.tsv".format(args.type))
+    study_table = get_geo_study_list(args.type)
+    # This contains the full table, need to trim it to GEO/SRA accession only to match expected output for pipeline
+    study_table.to_csv(output_file, sep='\t', index=False, header=False)


### PR DESCRIPTION
The pipeline for batch GEO currently relies on ENA study lists provided by the RNA-seqer endpoints. The logic of the  `rnaseq_ena_gse_pooling.py` script was to start with the ENA bulk or single-cell RNA-seq study lists. Then look up GEO accessions individually and filter out studies that are not in GEO. 

I have replaced this with a call to the ENA browser API to fetch studies that 
1) have raw data in SRA ("read_study")
2) have experiments with the annotation "library source: transcriptomic" 
3) have been brokered by GEO ("center_name: geo")

The script is collecting the BioProject accession, SRA study accession, GEO accession, title and organism. The title is used to separate studies into a bulk and a single-cell list. The output matches the previous script and contains only the GEO and SRA study accessions mapping.

We will lose the "not_in_GEO" list that was generated as a by-product of the old logic. This file is not used further by the pipeline. It was intended for curators. It is somewhat out of scope and not very useful to curators (as ArrayExpress-brokered ENA studies were not filtered). 
